### PR TITLE
[FIX] 로그인/회원가입 수정사항

### DIFF
--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/controller/MemberController.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/controller/MemberController.java
@@ -1,9 +1,8 @@
 package com.huruhuru.huruhuru.controller;
 
-import com.huruhuru.huruhuru.dto.request.member.MemberSignInRequest;
+import com.huruhuru.huruhuru.dto.request.member.MemberAuthRequest;
 import com.huruhuru.huruhuru.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,7 +30,7 @@ public class MemberController {
      */
 
     @PostMapping("signup")
-    public ResponseEntity<Map<String, Object>> signup(@RequestBody MemberSignInRequest request) {
+    public ResponseEntity<Map<String, Object>> signup(@RequestBody MemberAuthRequest request) {
         Long id = memberService.save(request);
         Map<String, Object> response = new HashMap<>();
         response.put("id", id);
@@ -39,19 +38,10 @@ public class MemberController {
     }
 
     @PostMapping("login")
-    public ResponseEntity<Map<String, Object>> login(@RequestBody MemberSignInRequest request) {
-        String token = memberService.login(request);
-        Map<String, Object> response = new HashMap<>();
-        response.put("token", token);
+    public ResponseEntity<Map<String, Object>> login(@RequestBody MemberAuthRequest request) {
+        Map<String, Object> response = memberService.login(request);
         return ResponseEntity.ok(response);
     }
-
-//    @GetMapping("logout")
-//    public String logout(HttpServletRequest request, HttpServletResponse response) {
-//        new SecurityContextLogoutHandler().logout(request, response,
-//                SecurityContextHolder.getContext().getAuthentication());
-//        return "redirect:/";
-//    }
 
 
     /*

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/controller/MemberController.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/controller/MemberController.java
@@ -63,6 +63,9 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
-    // TODO: 특정 사용자 정보를 조회하는 API
-
+    @GetMapping("{memberId}")
+    public ResponseEntity<MemberEntity> getMember(@PathVariable("memberId") Long memberId) {
+        MemberEntity member = memberService.getMember(memberId);
+        return ResponseEntity.ok(member);
+    }
 }

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/dto/request/member/MemberAuthRequest.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/dto/request/member/MemberAuthRequest.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @Setter
-public class MemberSignInRequest {
+public class MemberAuthRequest {
 
     @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickname;

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/global/config/SecurityConfig.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/global/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(new AntPathRequestMatcher("/signup")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/login")).permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/")).permitAll()
+//                        .requestMatchers(new AntPathRequestMatcher("/")).permitAll()
 //                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()) // 나머지 경로는 jwt 인증 해야함
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // JWT를 통해 인증된 사용자를 식별하는 필터

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/global/config/jwt/JwtTokenProvider.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/global/config/jwt/JwtTokenProvider.java
@@ -30,13 +30,10 @@ public class JwtTokenProvider {
         JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateToken(Authentication authentication, Long expiredTokenTime) {
-        final Date now = new Date();
-
+    public String generateToken(Authentication authentication) {
         // Claim: JWT 토큰에 저장되는 정보
         final Claims claims = Jwts.claims()
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + expiredTokenTime));
+                .setIssuedAt(new Date());
 
         // 사용자의 id를 Claim에 저장
         MemberEntity memberEntity = (MemberEntity) authentication.getPrincipal();
@@ -62,8 +59,6 @@ public class JwtTokenProvider {
             return JwtValidationType.VALID_JWT;
         } catch (MalformedJwtException ex) {
             return JwtValidationType.INVALID_JWT_TOKEN;
-        } catch (ExpiredJwtException ex) {
-            return JwtValidationType.EXPIRED_JWT_TOKEN;
         } catch (UnsupportedJwtException ex) {
             return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
         } catch (IllegalArgumentException ex) {

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/global/exception/GlobalExceptionHandler.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/global/exception/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
         String message = "이미 존재하는 닉네임입니다.";
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse(message));
     }
 

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/service/MemberService.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/service/MemberService.java
@@ -53,14 +53,14 @@ public class MemberService implements UserDetailsService {
 
         // nickname이 일치하는 Member가 없는 경우
         if (optionalMember.isEmpty()) {
-            throw new AuthenticationException("닉네임이 존재하지 않습니다.") {};
+            throw new AuthenticationException("닉네임 또는 비밀번호가 일치하지 않습니다.") {};
         }
 
         MemberEntity member = optionalMember.get();
 
         // password가 일치하지 않으면 null 반환
         if(!passwordEncoder.matches(dto.getPassword(), member.getPassword())) {
-            throw new AuthenticationException("비밀번호가 일치하지 않습니다.") {};
+            throw new AuthenticationException("닉네임 또는 비밀번호가 일치하지 않습니다.") {};
 
         }
 

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/service/MemberService.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/service/MemberService.java
@@ -83,8 +83,6 @@ public class MemberService implements UserDetailsService {
 
     /**
      * ID로 회원 조회
-     * @param id
-     * @return
      */
     public MemberEntity getMember(Long id) {
         return memberJpaRepository.findById(id).orElse(null);
@@ -92,8 +90,6 @@ public class MemberService implements UserDetailsService {
 
     /**
      * 닉네임으로 회원 조회
-     * @param nickname
-     * @return
      */
     @Override
     @Transactional


### PR DESCRIPTION
## 🍍 Description
<!-- 작업한 내용을 적어주세요 -->
- 회원가입 닉네임 중복: 400 BAD REQUEST -> 409 CONFLICT(중복)으로 status code 변경
- 로그인 시: 닉네임 틀렸든 비밀번호 틀렸든 에러 메세지 '닉네임 혹은 비밀번호가 틀렸습니다'로 통일
- jwt 유효기간 삭제
- 로그인 시 memberId도 함께 반환하도록 dto 수정
- memberId로 멤버 정보 조회하는 API 생성

</br>

## 🍒 Test
<!-- 테스트 방법에 대해 설명해주세요 -->

</br>

#### 🍏 Screenshot
<!-- 테스트 결과 사진을 캡쳐하여 올려주세요 -->
- 멤버 id로 정보 조회
![image](https://github.com/huru-huru/huruhuru-Server/assets/71963320/11e4bcf3-826f-4d27-8fea-985cce8ebb36)

- 로그인 시 token, memberId 반환
![image](https://github.com/huru-huru/huruhuru-Server/assets/71963320/9d306f17-5a88-4812-bb4c-e93bfdaf825c)


</br>

## 🥝 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
- Resolved: #11 
