### PR TITLE
chore: /score 호출 시 test2의 횟수 대신 member의 수 반환

### DIFF
--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/controller/MemberController.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/controller/MemberController.java
@@ -68,11 +68,11 @@ public class MemberController {
             System.out.println("ID: " + member.getId() + ", Nickname: " + member.getNickname() + ", Score: " + member.getTotalBestScore() + ", Test Count: " + member.getTestCount());
         });
         MemberRankingGetResponse member = memberService.getMemberRankingById(memberId);
-        Long test2Count = questionService.getTest2Count();
+        Long memberCount = memberService.getMemberCount();
         Map<String, Object> response = new HashMap<>();
         response.put("Top10", memberRanking);
         response.put("MyRanking", member);
-        response.put("test2Count", test2Count);
+        response.put("test2Count", memberCount);
         return ResponseEntity.ok(response);
     }
 

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/controller/QuestionController.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/controller/QuestionController.java
@@ -23,6 +23,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import java.lang.reflect.Member;
 import java.util.List;
@@ -47,6 +48,7 @@ public class QuestionController {
     }
 
     // totalTestCount 1 증가
+    @Transactional
     @PutMapping
     public ResponseEntity<Map<String, Long>> plusTotalTestCount(@RequestParam("category") Long category, @RequestParam("theme") Long theme) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/repository/MemberJpaRepository.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/repository/MemberJpaRepository.java
@@ -13,21 +13,7 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
     boolean existsByNickname(String nickname);
     Optional<MemberEntity> findByNickname(String nickname);
 
-//    @Query("SELECT m FROM MemberEntity m JOIN m.scoreList s " +
-//            "GROUP BY m.id " +
-//            "ORDER BY SUM(s.bestScore) DESC, m.testCount DESC limit 10")
-//    List<MemberEntity> findTop10MembersOrderByBestScoreSumAndTestCount();
 
-    @Query("SELECT m FROM MemberEntity m JOIN m.scoreList s " +
-            "GROUP BY m.id " +
-            "ORDER BY SUM(s.bestScore) DESC, m.testCount DESC")
-    List<MemberEntity> findTop10MembersOrderByBestScoreSumAndTestCount();
-
-
-//    @Query("SELECT m FROM MemberEntity m LEFT JOIN m.scoreList s " +
-//            "GROUP BY m.id " +
-//            "ORDER BY SUM(s.bestScore) DESC, m.testCount DESC")
-//    List<MemberEntity> findMembersOrderByBestScoreSumAndTestCount();
 
     @Query("SELECT m FROM MemberEntity m LEFT JOIN m.scoreList s " +
             "GROUP BY m.id " +
@@ -36,4 +22,10 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
 
     @Query("SELECT m FROM MemberEntity m ORDER BY m.totalBestScore DESC, m.testCount DESC limit 10")
     List<MemberEntity> findMembersOrderByBestScoreSumAndTestCountRank();
+
+//    @Query("SELECT m FROM MemberEntity m JOIN m.scoreList s " +
+//            "GROUP BY m.id " +
+//            "ORDER BY SUM(s.bestScore) DESC, m.testCount DESC")
+//    List<MemberEntity> findTop10MembersOrderByBestScoreSumAndTestCount();
+
 }

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/repository/QuestionJpaRepository.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/repository/QuestionJpaRepository.java
@@ -27,9 +27,9 @@ public interface QuestionJpaRepository extends JpaRepository<QuestionEntity, Lon
     @Query("SELECT SUM(q.testCount) FROM QuestionEntity q WHERE q.category = :category AND q.theme = :theme")
     Optional<Long> getTestCountByCategoryAndTheme(@Param("category") Long category, @Param("theme") Long theme);
 
-    // test2의 testCount
-    @Query("SELECT SUM(q.testCount) FROM QuestionEntity q WHERE q.category = 2")
-    Optional<Long> getTest2Count();
+    // test2의 testCount -> member의 수를 전달하는 것으로 변경
+//    @Query("SELECT SUM(q.testCount) FROM QuestionEntity q WHERE q.category = 2")
+//    Optional<Long> getTest2Count();
 
     List<QuestionEntity> findByCategoryAndTheme(Long category, Long theme, Sort sort);
 

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/service/MemberService.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/service/MemberService.java
@@ -126,4 +126,8 @@ public class MemberService implements UserDetailsService {
         throw new MemberException.MemberNotFoundException("Member with id " + memberId + " not found");
     }
 
+    public Long getMemberCount() {
+        return memberJpaRepository.count();
+    }
+
 }

--- a/huruhuru/src/main/java/com/huruhuru/huruhuru/service/QuestionService.java
+++ b/huruhuru/src/main/java/com/huruhuru/huruhuru/service/QuestionService.java
@@ -47,9 +47,9 @@ public class QuestionService {
         return questionJpaRepository.findByCategoryAndTheme(category, theme, sort);
     }
 
-    public Long getTest2Count() {
-        return questionJpaRepository.getTest2Count().orElse(0L);
-    }
+//    public Long getTest2Count() {
+//        return questionJpaRepository.getTest2Count().orElse(0L);
+//    }
 
 
     @Transactional


### PR DESCRIPTION
## 🍍 Description
- /score 로 랭킹 받아올 시 기존에 test2의 횟수를 반환했던 것을 member의 수를 반환하도록 변경했습니다.
- 프론트가 이미 이를 토대로 개발을 했기에,, test2라고 return되는 것은 그대로 두었습니다.
- 이외 필요 없어진 메서드 주석 처리 및 삭제

</br>

## 🍒 Test
postman을 통해 test

</br>

#### 🍏 Screenshot
![image](https://github.com/huru-huru/huruhuru-Server/assets/102143229/b42fa9bc-6ac4-48d5-981f-e635b5ef7ed2)
- test2Count라고 출력되지만 member의 수를 뜻합니다

</br>

## 🥝 Related Issue
- Resolved: #이슈번호

</br>

## 🫐 Reference
- 
